### PR TITLE
Fixes more than 1 result in Active Directory

### DIFF
--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -513,9 +513,12 @@ class LDAPAuthenticator(Authenticator):
                 search_scope=ldap3.SUBTREE,
                 attributes=self.user_membership_attribute if self.allowed_groups else list(),
                 paged_size=2)
+            
+            # remove all searchResRef from response
+            conn.response = [search_ref for search_ref in conn.response if 'type' in search_ref and search_ref['type'] != 'searchResRef']                       
 
             # handle abnormal search results
-            if not conn.response or len(conn.response) > 1:
+            if (not conn.response or len(conn.response) > 1) and not active_directory:            
                 self.log.error(("LDAP search '{}' returned {} results. " +
                                 "Please narrow search to 1 result").format(
                                     auth_user_search_filter, len(conn.response)))


### PR DESCRIPTION
When Active Directory has several domain trees, will respond with an array with the DN and the references. This removes all the references from the array, leaving only the search results entries.